### PR TITLE
Build (#15)

### DIFF
--- a/Daml.Ledger.Builder.csproj
+++ b/Daml.Ledger.Builder.csproj
@@ -1,0 +1,62 @@
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="AutoBuild">
+  
+  <Target Name="Build" DependsOnTargets="AutoBuild">
+  </Target>
+
+  <Target Name="AutoBuild" DependsOnTargets="Reactive;Automation;BindingsExample;TestExample">
+  </Target>
+
+  <Target Name="Api">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Api</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="Fragment">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Fragment</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="Client" DependsOnTargets="Api;Fragment">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Client</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="Reactive" DependsOnTargets="Client">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Client.Reactive</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="Automation" DependsOnTargets="Reactive">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Automation</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="BindingsExample" DependsOnTargets="Reactive;Client">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Examples.Bindings</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="TestExample" DependsOnTargets="Client">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Examples.Test</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <PropertyGroup>
+    <ProjectGuid>{48DB49ED-97C8-4B96-B8F5-0498F3A1B373}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>

--- a/Daml.Ledger.sln
+++ b/Daml.Ledger.sln
@@ -13,7 +13,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Client", "src\D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Automation", "src\Daml.Ledger.Automation\Daml.Ledger.Automation.csproj", "{50C8736B-B297-49C1-8F15-ADBEC7C960C3}"
 	ProjectSection(ProjectDependencies) = postProject
-		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1} = {F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}
 		{658CEB77-4F21-40B9-9963-896C41E64B67} = {658CEB77-4F21-40B9-9963-896C41E64B67}
 	EndProjectSection
 EndProject
@@ -37,6 +36,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Examples.Bindin
 	ProjectSection(ProjectDependencies) = postProject
 		{658CEB77-4F21-40B9-9963-896C41E64B67} = {658CEB77-4F21-40B9-9963-896C41E64B67}
 		{C28365C5-6F64-4468-8FFC-93121553C2EA} = {C28365C5-6F64-4468-8FFC-93121553C2EA}
+		{68C093F1-5FA2-4DA9-8A84-50782FAAF022} = {68C093F1-5FA2-4DA9-8A84-50782FAAF022}
 	EndProjectSection
 EndProject
 Global
@@ -45,6 +45,8 @@ Global
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
+		ReleaseNuget|Any CPU = ReleaseNuget|Any CPU
+		ReleaseNuget|x86 = ReleaseNuget|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}.Release|x86.ActiveCfg = Release|Any CPU
 		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}.Release|x86.Build.0 = Release|Any CPU
+		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -63,6 +69,10 @@ Global
 		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.Release|Any CPU.Build.0 = Release|Any CPU
 		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.Release|x86.ActiveCfg = Release|Any CPU
 		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.Release|x86.Build.0 = Release|Any CPU
+		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{68C093F1-5FA2-4DA9-8A84-50782FAAF022}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 		{658CEB77-4F21-40B9-9963-896C41E64B67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{658CEB77-4F21-40B9-9963-896C41E64B67}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{658CEB77-4F21-40B9-9963-896C41E64B67}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -71,6 +81,10 @@ Global
 		{658CEB77-4F21-40B9-9963-896C41E64B67}.Release|Any CPU.Build.0 = Release|Any CPU
 		{658CEB77-4F21-40B9-9963-896C41E64B67}.Release|x86.ActiveCfg = Release|Any CPU
 		{658CEB77-4F21-40B9-9963-896C41E64B67}.Release|x86.Build.0 = Release|Any CPU
+		{658CEB77-4F21-40B9-9963-896C41E64B67}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{658CEB77-4F21-40B9-9963-896C41E64B67}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{658CEB77-4F21-40B9-9963-896C41E64B67}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{658CEB77-4F21-40B9-9963-896C41E64B67}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -79,6 +93,10 @@ Global
 		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.Release|x86.ActiveCfg = Release|Any CPU
 		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.Release|x86.Build.0 = Release|Any CPU
+		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{50C8736B-B297-49C1-8F15-ADBEC7C960C3}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 		{C28365C5-6F64-4468-8FFC-93121553C2EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C28365C5-6F64-4468-8FFC-93121553C2EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C28365C5-6F64-4468-8FFC-93121553C2EA}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -87,6 +105,10 @@ Global
 		{C28365C5-6F64-4468-8FFC-93121553C2EA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C28365C5-6F64-4468-8FFC-93121553C2EA}.Release|x86.ActiveCfg = Release|Any CPU
 		{C28365C5-6F64-4468-8FFC-93121553C2EA}.Release|x86.Build.0 = Release|Any CPU
+		{C28365C5-6F64-4468-8FFC-93121553C2EA}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{C28365C5-6F64-4468-8FFC-93121553C2EA}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{C28365C5-6F64-4468-8FFC-93121553C2EA}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{C28365C5-6F64-4468-8FFC-93121553C2EA}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 		{5906A42A-1688-4277-B03C-A54605C1D9D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5906A42A-1688-4277-B03C-A54605C1D9D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5906A42A-1688-4277-B03C-A54605C1D9D9}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -95,6 +117,10 @@ Global
 		{5906A42A-1688-4277-B03C-A54605C1D9D9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5906A42A-1688-4277-B03C-A54605C1D9D9}.Release|x86.ActiveCfg = Release|Any CPU
 		{5906A42A-1688-4277-B03C-A54605C1D9D9}.Release|x86.Build.0 = Release|Any CPU
+		{5906A42A-1688-4277-B03C-A54605C1D9D9}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{5906A42A-1688-4277-B03C-A54605C1D9D9}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{5906A42A-1688-4277-B03C-A54605C1D9D9}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{5906A42A-1688-4277-B03C-A54605C1D9D9}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -103,6 +129,10 @@ Global
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.Release|x86.ActiveCfg = Release|Any CPU
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.Release|x86.Build.0 = Release|Any CPU
+		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The library is considered experimental, so breaking changes are to be expected. 
 
 The library currently targets `.Net Standard 2.0` so it can be used from projects targeting the .Net Framework, .Net Core or Mono.
 
-The build process has been tested on 64bit Windows 10 (with WSl 1 for the bash shell), MacOS Mojave (v10.14.5) and Catalina (v10.15.2), and Ubuntu 18.04.3 (under Hyper-V).
+The build process has been tested on 64bit Windows 10 (with WSl 1 for the bash shell), MacOS Catalina (v10.15.2), and Ubuntu 18.04.3 (under Hyper-V).
 
 # Support
 
@@ -30,10 +30,11 @@ The Daml.Ledger solution references the following projects:
   Daml.Ledger.Client            - a client wrapper around the Ledger API classes
   Daml.Ledger.Client.Reactive   - a rudimentary wrapper of Daml.Ledger.Client to provide a more reactive interface
   Daml.Ledger.Automation        - a minimal implementation of stateful and stateless automation bots
-  Daml.Ledger.Quickstart        - an example project utilising the Test DAML template
+  Daml.Ledger.Examples.Test     - an example project utilising the Test DAML template
+  Daml.Ledger.Examples.Bindings - an example project demonstrating some of the Bindings - based on the ex-java-bindings example project
 ```
 
-Nuget packages are now created (but haven't been published) for the following:
+Nuget packages can now be created using the build configuration `ReleaseNuget` (but haven't been published) for the following:
 ```
   Daml.Ledger.Fragment.<ver>.nupkg
   Daml.Ledger.Api.<ver>.nupkg 
@@ -48,11 +49,9 @@ Nuget packages are built for several of the projects and are placed in the `pack
 Note that when making source changes and rebuiding, or changing releases, then the previous versions of the nuget packages will likely be in the nuget cache and dependencies 
 will be resolved from there in preference to the `packages` folder. 
 
-Therefore you may have to flush the nuget cache (for example `nuget locals all -clear` to clear the whole cache, or on Ubuntu delete the cached packages from your ~/.nuget folder) in order to refresh the nuget cache.  
+Therefore you may have to flush the nuget cache (for example `nuget locals all -clear` to clear the whole cache, or on Ubuntu delete the cached packages from your `~/.nuget folder`) in order to refresh the nuget cache.  
 
-Release builds of all projects that have dependencies use nuget package references for the Release build, but project references for the Debug build to ease debugging.
-
-When running the examples with `dotnet run` it appears that nuget linkages are used if available.
+Builds of all projects that have dependencies use nuget package references for the `ReleaseNuget` build configuration, but project references for the Debug build to ease debugging.
 
 ## Prerequisites
 
@@ -95,18 +94,26 @@ up the line-ending differences as a change. So be consistent with which type of 
 Also note that if Visual Studio Code is launched from the bash shell of WSL then it may complain that it requires the dotnet SDK to be installed in WSL in
 order to build. This has not been tested so prefer to run VSC from a Windows shell.
 
-## Building the library
+### Ubuntu
 
-To build the solution using `msbuild`:
-```
-nuget restore
-msbuild Daml.Ledger.sln
-```
+The nuget build appears ot be broken because of a conflict between .NETSTandard and .NET Core. This may be fixed in future with an upgrade to the Google.Api.CommonProtos package. 
 
-To build the solution using `dotnet`:
+## Building the libraries/Examples
+
+The Debug and Release configuration of the projects can be built using the `Daml.Ledger.sln` solution file, or the `Daml.Ledger.Builder.csproj` file:
 ```
-dotnet build
+dotnet build Daml.Ledger.sln -C Debug|Release
 ```
+or 
+```
+dotnet build Daml.Ledger.Builder.csproj -c Debug|Release
+```
+The ReleaseNuget configuration of the projects should only be built using the `Daml.Ledger.Builder.csproj` file as this will enforce a strict ordering on the build which will ensure that the required nuget packages are available at the correct stages of the build:
+```
+dotnet build Daml.Ledger.Builder.csproj -c ReleaseNuget
+```
+Building the ReleaseNUget configuration with either `Daml.Ledger.sln` or Visual Studio may or may not work depending on the presence or not of the base nuget packages (e.g. `Daml.Ledger.Api`), and in any case Visual Studio appears to be inconsistent in being able to resolve 
+the project interdependencies.
 
 ## (Re) Generating the bindings
 

--- a/packages/ignoreme
+++ b/packages/ignoreme
@@ -1,1 +1,0 @@
-File to force a packages folder on clone - required for nuget resolve as configured as a local nuget source

--- a/src/Daml.Ledger.Api/Daml.Ledger.Api.csproj
+++ b/src/Daml.Ledger.Api/Daml.Ledger.Api.csproj
@@ -2,20 +2,34 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Daml.Ledger.Api</PackageId>
     <RootNamespace>Com.DigitalAsset.Ledger.Api.V1s</RootNamespace>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'ReleaseNuget'">
+    <PackageId>Daml.Ledger.Api</PackageId>
     <PackageTags>.NET C# DAML Ledger Api</PackageTags>
     <Product>DAML .NET Ledger Api</Product>
     <Authors>Georg Schneider</Authors>
     <Company>Digital Asset</Company>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Configuration>Release</Configuration>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>$(ProjectDir)..\..\packages\</PackageOutputPath>
     <PackageFile>$(PackageId).$(Version).nupkg</PackageFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseNuget' ">
+    <DebugType></DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\ReleaseNuget</OutputPath>
+    <DefineConstants></DefineConstants>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>obj\ReleaseNuget</IntermediateOutputPath>
+    <NoWarn></NoWarn>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Folder Include="V1\Admin\" />
     <Folder Include="V1\Testing\" />
@@ -61,5 +75,9 @@
 
     </When>
   </Choose>
+
+  <Target Name="InstallPackage" Condition="'$(Configuration)' == 'ReleaseNuget'" AfterTargets="Pack"> 
+    <Exec Command="nuget install $(PackageId) -Version $(Version) -OutputDirectory $(PackageOutputPath)" />
+  </Target>
 
 </Project>

--- a/src/Daml.Ledger.Automation/Daml.Ledger.Automation.csproj
+++ b/src/Daml.Ledger.Automation/Daml.Ledger.Automation.csproj
@@ -2,22 +2,36 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Daml.Ledger.Automation</PackageId>
     <RootNamespace>Daml.Ledger.Automation</RootNamespace>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'ReleaseNuget'">
+    <PackageId>Daml.Ledger.Automation</PackageId>
     <PackageTags>.NET DAML Ledger Automation</PackageTags>
     <Product>.NET DAML Ledger Automation</Product>
     <Authors>Georg Schneider</Authors>
     <Company>Digital Asset</Company>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Configuration>Release</Configuration>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>$(ProjectDir)..\..\packages\</PackageOutputPath>
     <PackageFile>$(PackageId).$(Version).nupkg</PackageFile>
   </PropertyGroup>
 
-   <Choose>
-    <When Condition="'$(Configuration)' == 'Release'">
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseNuget' ">
+    <DebugType></DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\ReleaseNuget</OutputPath>
+    <DefineConstants></DefineConstants>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>obj\ReleaseNuget</IntermediateOutputPath>
+    <NoWarn></NoWarn>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(Configuration)' == 'ReleaseNuget'">
       <ItemGroup>
         <PackageReference Include="Daml.Ledger.Client" Version="$(Version)" />
         <ProjectReference Include="..\Daml.Ledger.Api\Daml.Ledger.Api.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
@@ -31,5 +45,9 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
+
+  <Target Name="InstallPackage" Condition="'$(Configuration)' == 'ReleaseNuget'" AfterTargets="Pack"> 
+    <Exec Command="nuget install $(PackageId) -Version $(Version) -OutputDirectory $(PackageOutputPath)" />
+  </Target>
 
 </Project>

--- a/src/Daml.Ledger.Automation/nuget.config
+++ b/src/Daml.Ledger.Automation/nuget.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="local" value="./packages" />
+    <add key="local" value="../../packages" />
   </packageSources>
 </configuration>

--- a/src/Daml.Ledger.Client.Reactive/Daml.Ledger.Client.Reactive.csproj
+++ b/src/Daml.Ledger.Client.Reactive/Daml.Ledger.Client.Reactive.csproj
@@ -2,26 +2,39 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-     <PackageId>Daml.Ledger.Client.Reactive</PackageId>
     <RootNamespace>Daml.Ledger.Client.Reactive</RootNamespace>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'ReleaseNuget'">
+    <PackageId>Daml.Ledger.Client.Reactive</PackageId>
     <PackageTags>.net C# daml ledger Rx.Net api</PackageTags>
     <Product>net reactive bindings</Product>
     <Authors>Georg Schneider</Authors>
     <Company>Digital Asset</Company>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Configuration>Release</Configuration>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>$(ProjectDir)..\..\packages\</PackageOutputPath>
     <PackageFile>$(PackageId).$(Version).nupkg</PackageFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseNuget' ">
+    <DebugType></DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\ReleaseNuget</OutputPath>
+    <DefineConstants></DefineConstants>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>obj\ReleaseNuget</IntermediateOutputPath>
+    <NoWarn></NoWarn>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="4.1.5" />
   </ItemGroup>
 
   <Choose>
-    <When Condition="'$(Configuration)' == 'Release'">
+    <When Condition="'$(Configuration)' == 'ReleaseNuget'">
       <ItemGroup>
         <PackageReference Include="Daml.Ledger.Client" Version="$(Version)" />
         <ProjectReference Include="..\Daml.Ledger.Client\Daml.Ledger.Client.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
@@ -33,5 +46,9 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
+
+  <Target Name="InstallPackage" Condition="'$(Configuration)' == 'ReleaseNuget'" AfterTargets="Pack"> 
+    <Exec Command="nuget install $(PackageId) -Version $(Version) -OutputDirectory $(PackageOutputPath)" />
+  </Target>
 
 </Project>

--- a/src/Daml.Ledger.Client.Reactive/nuget.config
+++ b/src/Daml.Ledger.Client.Reactive/nuget.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="local" value="./packages" />
+    <add key="local" value="../../packages" />
   </packageSources>
 </configuration>

--- a/src/Daml.Ledger.Client/Daml.Ledger.Client.csproj
+++ b/src/Daml.Ledger.Client/Daml.Ledger.Client.csproj
@@ -2,20 +2,33 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Daml.Ledger.Client</PackageId>
     <RootNamespace>Daml.Ledger.Client</RootNamespace>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'ReleaseNuget'">
+    <PackageId>Daml.Ledger.Client</PackageId>
     <PackageTags>.NET C# DAML Ledger Client</PackageTags>
     <Product>DAML .NET Ledger Client</Product>
     <Authors>Georg Schneider</Authors>
     <Company>Digital Asset</Company>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Configuration>Release</Configuration>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>$(ProjectDir)..\..\packages\</PackageOutputPath>
     <PackageFile>$(PackageId).$(Version).nupkg</PackageFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseNuget' ">
+    <DebugType></DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\ReleaseNuget</OutputPath>
+    <DefineConstants></DefineConstants>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>obj\ReleaseNuget</IntermediateOutputPath>
+    <NoWarn></NoWarn>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
   <ItemGroup>
     <Folder Include="Admin\" />
     <Folder Include="Auth\" />
@@ -23,7 +36,7 @@
   </ItemGroup>
 
    <Choose>
-    <When Condition="'$(Configuration)' == 'Release'">
+    <When Condition="'$(Configuration)' == 'ReleaseNuget'">
       <ItemGroup>
         <PackageReference Include="Daml.Ledger.Api" Version="$(Version)" />
         <PackageReference Include="Daml.Ledger.Fragment" Version="$(Version)" />
@@ -38,5 +51,9 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
+
+  <Target Name="InstallPackage" Condition="'$(Configuration)' == 'ReleaseNuget'" AfterTargets="Pack"> 
+    <Exec Command="nuget install $(PackageId) -Version $(Version) -OutputDirectory $(PackageOutputPath)" />
+  </Target>
 
 </Project>

--- a/src/Daml.Ledger.Client/nuget.config
+++ b/src/Daml.Ledger.Client/nuget.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="local" value="./packages" />
+    <add key="local" value="../../packages" />
   </packageSources>
 </configuration>

--- a/src/Daml.Ledger.Examples.Bindings/Daml.Ledger.Examples.Bindings.csproj
+++ b/src/Daml.Ledger.Examples.Bindings/Daml.Ledger.Examples.Bindings.csproj
@@ -3,8 +3,19 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <Configuration>Release</Configuration>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseNuget' ">
+    <DebugType></DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\ReleaseNuget</OutputPath>
+    <DefineConstants></DefineConstants>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>obj\ReleaseNuget</IntermediateOutputPath>
+    <NoWarn></NoWarn>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Core" Version="1.22.0" />
   </ItemGroup>
@@ -16,9 +27,10 @@
   </ItemGroup>
 
   <Choose>
-    <When Condition="'$(Configuration)' == 'Release'">
+    <When Condition="'$(Configuration)' == 'ReleaseNuget'">
       <ItemGroup>
         <PackageReference Include="Daml.Ledger.Client" Version="$(Version)" />
+        <PackageReference Include="Daml.Ledger.Fragment" Version="$(Version)" />
         <ProjectReference Include="..\Daml.Ledger.Client\Daml.Ledger.Client.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
         <ProjectReference Include="..\Daml.Ledger.Fragment\Daml.Ledger.Fragment.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
       </ItemGroup>
@@ -26,6 +38,7 @@
     <Otherwise>
       <ItemGroup>
         <ProjectReference Include="..\Daml.Ledger.Client\Daml.Ledger.Client.csproj" />
+        <ProjectReference Include="..\Daml.Ledger.Fragment\Daml.Ledger.Fragment.csproj" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Daml.Ledger.Examples.Test/Daml.Ledger.Examples.Test.csproj
+++ b/src/Daml.Ledger.Examples.Test/Daml.Ledger.Examples.Test.csproj
@@ -3,14 +3,25 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <Configuration>Release</Configuration>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseNuget' ">
+    <DebugType></DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\ReleaseNuget</OutputPath>
+    <DefineConstants></DefineConstants>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>obj\ReleaseNuget</IntermediateOutputPath>
+    <NoWarn></NoWarn>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Core" Version="1.22.0" />
   </ItemGroup>
   
    <Choose>
-    <When Condition="'$(Configuration)' == 'Release'">
+    <When Condition="'$(Configuration)' == 'ReleaseNuget'">
       <ItemGroup>
         <PackageReference Include="Daml.Ledger.Client" Version="$(Version)" />
         <ProjectReference Include="..\Daml.Ledger.Client\Daml.Ledger.Client.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />

--- a/src/Daml.Ledger.Fragment/Daml.Ledger.Fragment.csproj
+++ b/src/Daml.Ledger.Fragment/Daml.Ledger.Fragment.csproj
@@ -2,20 +2,33 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Daml.Ledger.Fragment</PackageId>
     <RootNamespace>Com.DigitalAsset.Daml_Lf_1_7.DamlLf</RootNamespace>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'ReleaseNuget'">
+    <PackageId>Daml.Ledger.Fragment</PackageId>
     <PackageTags>.NET C# DAML Ledger Fragment</PackageTags>
     <Product>DAML .NET Ledger Fragment</Product>
     <Authors>Georg Schneider</Authors>
     <Company>Digital Asset</Company>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Configuration>Release</Configuration>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>$(ProjectDir)..\..\packages\</PackageOutputPath>
     <PackageFile>$(PackageId).$(Version).nupkg</PackageFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseNuget' ">
+    <DebugType></DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\ReleaseNuget</OutputPath>
+    <DefineConstants></DefineConstants>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>obj\ReleaseNuget</IntermediateOutputPath>
+    <NoWarn></NoWarn>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.9.0" />
     <PackageReference Include="Grpc" Version="1.22.0" />
@@ -53,5 +66,9 @@
 
     </When>
   </Choose>
+
+  <Target Name="InstallPackage" Condition="'$(Configuration)' == 'ReleaseNuget'" AfterTargets="Pack"> 
+    <Exec Command="nuget install $(PackageId) -Version $(Version) -OutputDirectory $(PackageOutputPath)" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
* Projects that build nuget packages install them after build. Tweaks some project dependencies in the solution and project files. New Daml.Ledger.Builder.csprog file to successfully build in correct order so missing nuget package dependencies don't break the build.

* Updated readme for build process

* Don't produce nuget packages for Debug builds

* Added Build target to Daml.Ledger.Builder.csproj for Ubuntu

* Added ReleaseNuget build configuration so a release build can be produced that doesn't use nuget, as nuget builds were failing on Ubuntu

* Windows build added x86 coonfig back